### PR TITLE
Solve unequal declaration of interface and class

### DIFF
--- a/lib/Ingenico/Connect/Sdk/ResourceLogger.php
+++ b/lib/Ingenico/Connect/Sdk/ResourceLogger.php
@@ -32,7 +32,7 @@ class ResourceLogger implements CommunicatorLogger
     }
 
     /** @inheritdoc */
-    public function logException($message, Exception $exception)
+    public function logException($message, \Exception $exception)
     {
         fwrite($this->resource, $this->getDatePrefix() . $message . PHP_EOL . (string) $exception . PHP_EOL);
     }

--- a/lib/Ingenico/Connect/Sdk/ResourceLogger.php
+++ b/lib/Ingenico/Connect/Sdk/ResourceLogger.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ingenico\Connect\Sdk;
 
+use Exception;
 use UnexpectedValueException;
 
 /**
@@ -32,7 +33,7 @@ class ResourceLogger implements CommunicatorLogger
     }
 
     /** @inheritdoc */
-    public function logException($message, \Exception $exception)
+    public function logException($message, Exception $exception)
     {
         fwrite($this->resource, $this->getDatePrefix() . $message . PHP_EOL . (string) $exception . PHP_EOL);
     }

--- a/lib/Ingenico/Connect/Sdk/SplFileObjectLogger.php
+++ b/lib/Ingenico/Connect/Sdk/SplFileObjectLogger.php
@@ -1,6 +1,8 @@
 <?php
 namespace Ingenico\Connect\Sdk;
 
+use Exception;
+
 /**
  * Class SplFileObjectLogger
  *


### PR DESCRIPTION
When testing in strict mode in PHP 7.1.10 and enabling logging as per the documentation, a fatal error occurs when injecting a Logger.

Given the following code:

```php
$communicatorConfiguration = new CommunicatorConfiguration(
	'xxxxxxx',
	'xxxxxxx=',
	'xxxxxxx',
	'xxxxxxx'
);
$connection = new DefaultConnection();
$communicator = new Communicator($connection, $communicatorConfiguration);

$client = new Client($communicator);
$client->enableLogging($logger);

$hostedCheckoutSpecificInput = new HostedCheckoutSpecificInput();
$hostedCheckoutSpecificInput->locale = "en_GB";
$hostedCheckoutSpecificInput->variant = "testVariant";

$amountOfMoney = new AmountOfMoney();
$amountOfMoney->amount = 2345;
$amountOfMoney->currencyCode = "USD";

$billingAddress = new Address();
$billingAddress->countryCode = "US";

$customer = new Customer();
$customer->billingAddress = $billingAddress;

$order = new Order();
$order->amountOfMoney = $amountOfMoney;
$order->customer = $customer;

$body = new CreateHostedCheckoutRequest();
$body->hostedCheckoutSpecificInput = $hostedCheckoutSpecificInput;
$body->order = $order;

$response = $client->merchant('xxxxxxx')->hostedcheckouts()->create($body);

```

It will throw the following error: 

```
PHP Fatal error:  Declaration of Ingenico\Connect\Sdk\ResourceLogger::logException($message, Ingenico\Connect\Sdk\Exception $exception) must be compatible with Ingenico\Connect\Sdk\CommunicatorLogger::logException($message, Exception $exception) in /var/www/html/vendor/ingenico-epayments/connect-sdk-php/lib/Ingenico/Connect/Sdk/ResourceLogger.php on line 11
PHP Stack trace:
PHP   1. {main}() /var/www/html/examples/GenerateIngenicoPayment.php:0
PHP   2. spl_autoload_call() /var/www/html/examples/GenerateIngenicoPayment.php:19
PHP   3. Composer\Autoload\ClassLoader->loadClass() /var/www/html/examples/GenerateIngenicoPayment.php:19
PHP   4. Composer\Autoload\includeFile() /var/www/html/vendor/composer/ClassLoader.php:322
PHP   5. include() /var/www/html/vendor/composer/ClassLoader.php:444
```

This commit fixes the issue.
