### PR TITLE
Add classmap for HTTP status code 201 on CaptureRequest

### DIFF
--- a/src/Ingenico/Connect/Sdk/Merchant/Payments.php
+++ b/src/Ingenico/Connect/Sdk/Merchant/Payments.php
@@ -199,6 +199,7 @@ class Payments extends Resource
         $this->context['paymentId'] = $paymentId;
         $responseClassMap = new ResponseClassMap();
         $responseClassMap->addResponseClassName(200, '\Ingenico\Connect\Sdk\Domain\Capture\CaptureResponse');
+        $responseClassMap->addResponseClassName(201, '\Ingenico\Connect\Sdk\Domain\Capture\CaptureResponse');
         return $this->getCommunicator()->post(
             $responseClassMap,
             $this->instantiateUri('/{apiVersion}/{merchantId}/payments/{paymentId}/capture'),


### PR DESCRIPTION
The Ogone endpoint will return HTTP Status code 201 for capture requests, which is currently not handled by the ResponseFactory. I'm not sure, if handling status code 200 is necessary at all, since, although the documentation states it will be returned, the API only returns HTTP status code 201 from my experiences.
